### PR TITLE
ZAIUS-12243: dynamic restrictions

### DIFF
--- a/lib/resque/plugins/job.rb
+++ b/lib/resque/plugins/job.rb
@@ -14,7 +14,7 @@ module Resque
             # and return
             payload = Resque.pop(queue)
             if payload
-              if !Object.const_get(payload['class']).repush(*payload['args'])
+              unless Object.const_get(payload['class']).repush_if_restricted(*payload['args'])
                 return new(queue, payload)
               end
             end

--- a/lib/resque/plugins/restriction.rb
+++ b/lib/resque/plugins/restriction.rb
@@ -77,11 +77,11 @@ module Resque
         # ensure we don't hold a concurrency slot
         concurrency_limiter.finish(concurrency_key) if concurrency_key
 
-        # reincrement the keys if one of the periods triggers DontPerform so
-        # that we accurately track capacity
-        keys_incremented.each {|k| Resque.redis.incrby(k, -1) }
+        # decrement the keys we incremented since we're not going to perform the job
+        # so we accurately track capacity
+        keys_incremented.each { |k| Resque.redis.incrby(k, -1) }
 
-        Resque.push restriction_queue_name, :class => to_s, :args => args
+        Resque.push(restriction_queue_name, class: to_s, args: args)
         raise Resque::Job::DontPerform
       end
 
@@ -138,7 +138,7 @@ module Resque
         false
       rescue IsRestrictedError
         # job is restricted, push to restriction queue
-        Resque.push restriction_queue_name, :class => to_s, :args => args
+        Resque.push(restriction_queue_name, class: to_s, args: args)
         true
       end
 

--- a/lib/resque/plugins/restriction/concurrency_limiter.rb
+++ b/lib/resque/plugins/restriction/concurrency_limiter.rb
@@ -1,0 +1,84 @@
+module Resque
+  module Plugins
+    module Restriction
+      # A redis-based concurrency limiter
+      # Allows a max number of concurrent jobs to run for a given key
+      # Assumes all workers clocks are synchronized (allows for 60s of clock skew)
+      # The heartbeat approach protects against catastrophic failure
+      # e.g., if a process is killed, the slot reservation will go stale,
+      # get ignored, and be cleaned up by other jobs
+      class ConcurrencyLimiter
+        JOB_ID_KEY           = 'restriction:concurrency_job_id'.freeze
+        CONCURRENT_HEARTBEAT = 15
+        MAX_CLOCK_SKEW       = 60
+        STALE_TTL            = MAX_CLOCK_SKEW + CONCURRENT_HEARTBEAT
+
+        # @param [Redis] redis
+        def initialize(redis)
+          # @type [Redis]
+          @redis = redis
+        end
+
+        # Try to reserve a concurrency slot for the given key and max concurrency
+        # @returns true if a slot is acquired, false otherwise
+        def try_start(key, concurrency)
+          @job_id = @redis.incr(JOB_ID_KEY)
+          now     = Time.now.to_i
+          result  = @redis.multi do
+            @redis.zadd(key, now, @job_id)
+            @redis.zcount(key, (now - STALE_TTL).to_s, (now + MAX_CLOCK_SKEW).to_s)
+          end
+
+          if result[1].to_i <= concurrency
+            start_heartbeat(key)
+            true
+          else
+            @redis.zrem(key, @job_id)
+            false
+          end
+        end
+
+        # Check if there is capacity for another job for the key given the max concurrency
+        def can_start?(key, concurrency)
+          now = Time.now.to_i
+          @redis.zcount(key, now - STALE_TTL, now + MAX_CLOCK_SKEW).to_i < concurrency
+        end
+
+        # Give up the reserved slot
+        def finish(key)
+          stop_heartbeat
+          return if @job_id.nil?
+          @redis.zrem(key, @job_id)
+          @job_id = nil
+        end
+
+        private
+
+        def perform_maintenance(key)
+          # Remove stale members (e.g., from a process that unwillingly exits)
+          @redis.zremrangebyscore(key, '0', (Time.now.to_i - STALE_TTL).to_s)
+        end
+
+        # Continually update the score (timestamp) for this job
+        # Keeps the job slot until the job is finished
+        def start_heartbeat(key)
+          stop_heartbeat
+          @thread = Thread.new do
+            perform_maintenance(key) if rand(100).zero?
+            loop do
+              sleep(CONCURRENT_HEARTBEAT)
+              @redis.pipelined do
+                @redis.zadd(key, Time.now.to_i, @job_id, xx: true)
+              end
+            end
+          end
+        end
+
+        def stop_heartbeat
+          @thread.kill.join if @thread
+          @thread = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/restriction/concurrency_limiter.rb
+++ b/lib/resque/plugins/restriction/concurrency_limiter.rb
@@ -67,9 +67,7 @@ module Resque
             perform_maintenance(key) if rand(100).zero?
             loop do
               sleep(CONCURRENT_HEARTBEAT)
-              @redis.pipelined do
-                @redis.zadd(key, Time.now.to_i, @job_id, xx: true)
-              end
+              @redis.zadd(key, Time.now.to_i, @job_id, xx: true)
             end
           end
         end

--- a/lib/resque/restriction.rb
+++ b/lib/resque/restriction.rb
@@ -1,3 +1,4 @@
 require 'resque'
 require 'resque/plugins/job'
 require 'resque/plugins/restriction'
+require 'resque/plugins/restriction/concurrency_limiter'

--- a/lib/resque/restriction/version.rb
+++ b/lib/resque/restriction/version.rb
@@ -1,5 +1,5 @@
 module Resque
   module Restriction
-    VERSION = '0.6.0'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/resque/job_spec.rb
+++ b/spec/resque/job_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Resque::Job do
     Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 11)
     3.times { Resque.push('restriction_normal', :class => 'OneHourRestrictionJob', :args => ['any args']) }
     expect(Resque.size('restriction_normal')).to eq 3
-    expect(OneHourRestrictionJob).to receive(:repush).exactly(3).times.and_return(true)
+    expect(OneHourRestrictionJob).to receive(:repush_if_restricted).exactly(3).times.and_return(true)
     Resque::Job.reserve('restriction_normal')
   end
 end

--- a/spec/resque/job_spec.rb
+++ b/spec/resque/job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Resque::Job do
   end
 
   it "should push back to restriction queue when still restricted" do
-    Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), -1)
+    Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 11)
     Resque.push('restriction_normal', :class => 'OneHourRestrictionJob', :args => ['any args'])
     expect(Resque::Job.reserve('restriction_normal')).to be_nil
     expect(Resque.pop('restriction_normal')).to eq({'class' => 'OneHourRestrictionJob', 'args' => ['any args']})
@@ -28,7 +28,7 @@ RSpec.describe Resque::Job do
   end
 
   it "should only push back queue_length times to restriction queue" do
-    Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), -1)
+    Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 11)
     3.times { Resque.push('restriction_normal', :class => 'OneHourRestrictionJob', :args => ['any args']) }
     expect(Resque.size('restriction_normal')).to eq 3
     expect(OneHourRestrictionJob).to receive(:repush).exactly(3).times.and_return(true)

--- a/spec/resque/plugins/restriction/concurrency_limiter_spec.rb
+++ b/spec/resque/plugins/restriction/concurrency_limiter_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+module Resque
+  module Plugins
+    module Restriction
+      RSpec.describe ConcurrencyLimiter do
+        KEY = 'limiter_test'.freeze
+
+        before(:suite) do
+          Resque.redis.flushall
+        end
+
+        after(:each) do
+          Resque.redis.flushall
+        end
+
+        it 'limits concurrency' do
+          limiter1 = ConcurrencyLimiter.new(Resque.redis)
+          limiter2 = ConcurrencyLimiter.new(Resque.redis)
+          limiter3 = ConcurrencyLimiter.new(Resque.redis)
+
+          expect(limiter1.try_start(KEY, 2)).to be_truthy
+          expect(limiter2.try_start(KEY, 2)).to be_truthy
+          expect(limiter3.try_start(KEY, 2)).to be_falsey
+          expect(Resque.redis.zcard(KEY)).to eq(2)
+
+          limiter1.finish(KEY)
+          limiter2.finish(KEY)
+          expect(Resque.redis.zcard(KEY)).to eq(0)
+        end
+
+        it 'limits concurrency across multiple keys' do
+          KEY2 = [KEY, 'foo'].join(':')
+          limiter1 = ConcurrencyLimiter.new(Resque.redis)
+          limiter2 = ConcurrencyLimiter.new(Resque.redis)
+          limiter3 = ConcurrencyLimiter.new(Resque.redis)
+
+          expect(limiter1.try_start(KEY, 1)).to be_truthy
+          expect(limiter2.try_start(KEY2, 1)).to be_truthy
+          expect(limiter3.try_start(KEY, 1)).to be_falsey
+          expect(limiter3.try_start(KEY2, 1)).to be_falsey
+          expect(Resque.redis.zcard(KEY)).to eq(1)
+          expect(Resque.redis.zcard(KEY2)).to eq(1)
+
+          limiter1.finish(KEY)
+          limiter2.finish(KEY2)
+          expect(Resque.redis.zcard(KEY)).to eq(0)
+          expect(Resque.redis.zcard(KEY2)).to eq(0)
+        end
+
+        it 'determines if concurrency would be limited' do
+          limiter1 = ConcurrencyLimiter.new(Resque.redis)
+          limiter2 = ConcurrencyLimiter.new(Resque.redis)
+
+          expect(limiter1.try_start(KEY, 1)).to be_truthy
+          expect(limiter2.can_start?(KEY, 1)).to be_falsey
+          expect(limiter2.can_start?(KEY, 2)).to be_truthy
+
+          limiter1.finish(KEY)
+        end
+
+        it 'kills the heartbeat thread' do
+          limiter1 = ConcurrencyLimiter.new(Resque.redis)
+
+          expect(limiter1.try_start(KEY, 1)).to be_truthy
+
+          thread = limiter1.instance_variable_get(:@thread)
+          expect(thread.alive?).to be_truthy
+
+          limiter1.finish(KEY)
+          expect(thread.alive?).to be_falsey
+          expect(limiter1.instance_variable_get(:@thread)).to be_nil
+        end
+
+        it 'has no negative side-effects if finish is called without start' do
+          limiter1 = ConcurrencyLimiter.new(Resque.redis)
+
+          limiter1.finish(KEY)
+          expect(Resque.redis.exists(KEY)).to be_falsey
+
+          expect(limiter1.try_start(KEY, 1)).to be_truthy
+
+          limiter1.finish(KEY)
+          limiter1.finish(KEY)
+          expect(Resque.redis.zcard(KEY)).to eq(0)
+        end
+
+        it 'refreshes the lock over time' do
+          limiter = ConcurrencyLimiter.new(Resque.redis)
+
+          # mock time so we can time-travel
+          mock_time = 1593719580
+          allow(Time).to receive(:now) { mock_time }
+          ConcurrencyLimiter.const_set(:CONCURRENT_HEARTBEAT, 0) # fast-forward heartbeat
+
+          expect(limiter.try_start(KEY, 1)).to be_truthy
+          expect(Resque.redis.zcard(KEY)).to eq(1)
+
+          job_id = Resque.redis.get(ConcurrencyLimiter::JOB_ID_KEY)
+          expect(Resque.redis.zscore(KEY, job_id)).to eq(mock_time)
+
+          mock_time += 15
+          sleep(0.01) # yield to heartbeat thread
+          expect(Resque.redis.zscore(KEY, job_id)).to eq(mock_time)
+
+          limiter.finish(KEY)
+        end
+
+        it 'ignores and removes stale locks' do
+          limiter = ConcurrencyLimiter.new(Resque.redis)
+
+          # mock time so we can time-travel
+          mock_time = 1593719580
+          allow(Time).to receive(:now) { mock_time }
+          # engage infinite improbability drive (make this the 1 in a hundred chance every time)
+          allow_any_instance_of(Object).to receive(:rand).and_return(0)
+
+          # insert a stale member
+          Resque.redis.zadd(KEY, 0, mock_time - 76)
+
+          expect(limiter.try_start(KEY, 1)).to be_truthy
+          expect(Resque.redis.zcard(KEY)).to eq(2)
+
+          sleep(0.01) # yield to heartbeat thread
+
+          limiter.finish(KEY)
+          expect(Resque.redis.zcard(KEY)).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/resque/plugins/restriction/concurrency_limiter_spec.rb
+++ b/spec/resque/plugins/restriction/concurrency_limiter_spec.rb
@@ -90,7 +90,7 @@ module Resque
 
           # mock time so we can time-travel
           mock_time = 1593719580
-          allow(Time).to receive(:now) { mock_time }
+          allow(Time).to receive(:now) { Time.at(mock_time) }
           ConcurrencyLimiter.const_set(:CONCURRENT_HEARTBEAT, 0) # fast-forward heartbeat
 
           expect(limiter.try_start(KEY, 1)).to be_truthy
@@ -111,7 +111,7 @@ module Resque
 
           # mock time so we can time-travel
           mock_time = 1593719580
-          allow(Time).to receive(:now) { mock_time }
+          allow(Time).to receive(:now) { Time.at(mock_time) }
           # engage infinite improbability drive (make this the 1 in a hundred chance every time)
           allow_any_instance_of(Object).to receive(:rand).and_return(0)
 

--- a/spec/resque/plugins/restriction_spec.rb
+++ b/spec/resque/plugins/restriction_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe Resque::Plugins::Restriction do
       Resque.redis.flushall
     end
 
-    it "should set execution number and decrement it when one job first executed" do
+    it "should set execution number and increment it when one job first executed" do
       result = perform_job(OneHourRestrictionJob, "any args")
-      expect(Resque.redis.get(OneHourRestrictionJob.redis_key(:per_hour))).to eq "9"
+      expect(Resque.redis.get(OneHourRestrictionJob.redis_key(:per_hour))).to eq "1"
     end
 
     it "should use restriction_identifier to set exclusive execution counts" do
@@ -77,8 +77,8 @@ RSpec.describe Resque::Plugins::Restriction do
       result = perform_job(IdentifiedRestrictionJob, 1)
       result = perform_job(IdentifiedRestrictionJob, 2)
 
-      expect(Resque.redis.get(IdentifiedRestrictionJob.redis_key(:per_hour, 1))).to eq "8"
-      expect(Resque.redis.get(IdentifiedRestrictionJob.redis_key(:per_hour, 2))).to eq "9"
+      expect(Resque.redis.get(IdentifiedRestrictionJob.redis_key(:per_hour, 1))).to eq "2"
+      expect(Resque.redis.get(IdentifiedRestrictionJob.redis_key(:per_hour, 2))).to eq "1"
     end
 
     it "should use dynamic restrictions" do
@@ -86,41 +86,41 @@ RSpec.describe Resque::Plugins::Restriction do
       result = perform_job(DynamicRestrictionJob, 1, :per_hour => 5)
       result = perform_job(DynamicRestrictionJob, 2, :per_hour => 10)
 
-      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_hour, 1))).to eq "3"
-      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_hour, 2))).to eq "9"
+      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_hour, 1))).to eq "2"
+      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_hour, 2))).to eq "1"
 
-      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_minute, 1))).to eq "3"
-      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_minute, 2))).to eq "4"
+      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_minute, 1))).to eq "2"
+      expect(Resque.redis.get(DynamicRestrictionJob.redis_key(:per_minute, 2))).to eq "1"
     end
 
-    it "should decrement execution number when one job executed" do
+    it "should increment execution number when one job executed" do
       Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 6)
       result = perform_job(OneHourRestrictionJob, "any args")
 
-      expect(Resque.redis.get(OneHourRestrictionJob.redis_key(:per_hour))).to eq "5"
+      expect(Resque.redis.get(OneHourRestrictionJob.redis_key(:per_hour))).to eq "7"
     end
 
-    it "should increment execution number when concurrent job completes" do
+    it "should decrement execution number when concurrent job completes" do
       t = Thread.new do
         perform_job(ConcurrentRestrictionJob, "any args")
       end
       sleep 0.1
-      expect(Resque.redis.get(ConcurrentRestrictionJob.redis_key(:concurrent))).to eq "0"
-      t.join
       expect(Resque.redis.get(ConcurrentRestrictionJob.redis_key(:concurrent))).to eq "1"
+      t.join
+      expect(Resque.redis.get(ConcurrentRestrictionJob.redis_key(:concurrent))).to eq "0"
     end
 
-    it "should increment execution number when concurrent job fails" do
+    it "should decrement execution number when concurrent job fails" do
       expect(ConcurrentRestrictionJob).to receive(:perform).and_raise("bad")
       perform_job(ConcurrentRestrictionJob, "any args") rescue nil
-      expect(Resque.redis.get(ConcurrentRestrictionJob.redis_key(:concurrent))).to eq "1"
+      expect(Resque.redis.get(ConcurrentRestrictionJob.redis_key(:concurrent))).to eq "0"
     end
 
-    it "should put the job into restriction queue when execution count < 0" do
-      Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 0)
+    it "should put the job into restriction queue when execution count > limit" do
+      Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 10)
       result = perform_job(OneHourRestrictionJob, "any args")
       # expect(result).to_not be(true)
-      expect(Resque.redis.get(OneHourRestrictionJob.redis_key(:per_hour))).to eq "0"
+      expect(Resque.redis.get(OneHourRestrictionJob.redis_key(:per_hour))).to eq "10"
       expect(Resque.redis.lrange("queue:restriction_normal", 0, -1)).to eq [Resque.encode(:class => "OneHourRestrictionJob", :args => ["any args"])]
     end
 
@@ -224,35 +224,35 @@ RSpec.describe Resque::Plugins::Restriction do
     context "multiple restrict" do
       it "should restrict per_minute" do
         result = perform_job(MultipleRestrictionJob, "any args")
-        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "9"
+        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "1"
         expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_300))).to eq "1"
         result = perform_job(MultipleRestrictionJob, "any args")
         result = perform_job(MultipleRestrictionJob, "any args")
-        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "8"
-        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_300))).to eq "0"
+        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "2"
+        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_300))).to eq "2"
       end
 
       it "should restrict per_hour" do
-        Resque.redis.set(MultipleRestrictionJob.redis_key(:per_hour), 1)
-        Resque.redis.set(MultipleRestrictionJob.redis_key(:per_300), 2)
+        Resque.redis.set(MultipleRestrictionJob.redis_key(:per_hour), 9)
+        Resque.redis.set(MultipleRestrictionJob.redis_key(:per_300), 0)
         result = perform_job(MultipleRestrictionJob, "any args")
-        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "0"
+        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "10"
         expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_300))).to eq "1"
         result = perform_job(MultipleRestrictionJob, "any args")
-        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "0"
+        expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_hour))).to eq "10"
         expect(Resque.redis.get(MultipleRestrictionJob.redis_key(:per_300))).to eq "1"
       end
     end
 
     context "repush" do
       it "should push restricted jobs onto restriction queue" do
-        Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), -1)
+        Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 10)
         expect(Resque).to receive(:push).once.with('restriction_normal', :class => 'OneHourRestrictionJob', :args => ['any args'])
         expect(OneHourRestrictionJob.repush('any args')).to be(true)
       end
 
       it "should not push unrestricted jobs onto restriction queue" do
-        Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 1)
+        Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 9)
         expect(Resque).not_to receive(:push)
         expect(OneHourRestrictionJob.repush('any args')).to be(false)
       end

--- a/spec/resque/plugins/restriction_spec.rb
+++ b/spec/resque/plugins/restriction_spec.rb
@@ -248,13 +248,13 @@ RSpec.describe Resque::Plugins::Restriction do
       it "should push restricted jobs onto restriction queue" do
         Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 10)
         expect(Resque).to receive(:push).once.with('restriction_normal', :class => 'OneHourRestrictionJob', :args => ['any args'])
-        expect(OneHourRestrictionJob.repush('any args')).to be(true)
+        expect(OneHourRestrictionJob.repush_if_restricted('any args')).to be(true)
       end
 
       it "should not push unrestricted jobs onto restriction queue" do
         Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), 9)
         expect(Resque).not_to receive(:push)
-        expect(OneHourRestrictionJob.repush('any args')).to be(false)
+        expect(OneHourRestrictionJob.repush_if_restricted('any args')).to be(false)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,3 +134,22 @@ class MultiCallRestrictionJob
   def self.perform(*args)
   end
 end
+
+class DynamicRestrictionJob
+  extend Resque::Plugins::Restriction
+
+  restrict :per_minute => 5
+
+  @queue = 'normal'
+
+  def self.restrictions(*args)
+    base_restrictions.merge(args[1])
+  end
+
+  def self.restriction_identifier(*args)
+    [self.to_s, args[0]].join(':')
+  end
+
+  def self.perform(*args)
+  end
+end


### PR DESCRIPTION
- Allows for dynamic restrictions based on the job arguments
- Allows for restrictions to change over time even against the same identifier key
- More robust concurrency, stops killed jobs/processes from restricting concurrency forever

Should be easier to review one commit at a time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/resque-restriction/1)
<!-- Reviewable:end -->
